### PR TITLE
feat(react-ensemble): add avoidReload prop to Timeline to allow alter…

### DIFF
--- a/packages/website/src/content/examples/live-reload.mdx
+++ b/packages/website/src/content/examples/live-reload.mdx
@@ -1,0 +1,92 @@
+```jsx live startHidden
+() => {
+  const getRandomX = React.useCallback(() => Math.random() * 500 - 250, []);
+  const getRandomY = React.useCallback(() => Math.random() * 150 + 50, []);
+
+  const getRandomDefaultState = React.useCallback(
+    () => ({
+      x: getRandomX(),
+      y: getRandomY()
+    }),
+    []
+  );
+
+  const getRandomTrack = React.useCallback(
+    () => [
+      {
+        duration: 1500,
+        state: {
+          x: { to: getRandomX() },
+          y: { to: getRandomY() }
+        }
+      }
+    ],
+    []
+  );
+
+  const [defaultState, setDefaultState] = React.useState(() =>
+    getRandomDefaultState()
+  );
+  const [track, setTrack] = React.useState(() => getRandomTrack());
+  const [animState, setAnimState] = React.useState(defaultState);
+
+  return (
+    <>
+      <Controller>
+        {props => (
+          <Timeline
+            {...props}
+            avoidReload={false}
+            defaultState={defaultState}
+            track={track}
+            onUpdate={({ state }) => setAnimState(state)}
+            endBehavior="boomerang"
+          />
+        )}
+      </Controller>
+      <div
+        style={{
+          height: 250,
+          width: "100%",
+          position: "relative",
+          display: "flex",
+          justifyContent: "center"
+        }}
+      >
+        <div
+          style={{
+            position: "relative",
+            borderRadius: 15,
+            width: 30,
+            height: 30,
+            backgroundColor: "__primary",
+            left: animState.x,
+            top: animState.y - 15
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            width: "100%",
+            display: "flex",
+            justifyContent: "flex-end"
+          }}
+        >
+          <div>
+            ({Math.floor(defaultState.x)}, {Math.floor(defaultState.y)}) to (
+            {Math.floor(track[0].state.x.to)}, {Math.floor(track[0].state.y.to)})
+            <button
+              onClick={() => {
+                setDefaultState(getRandomDefaultState());
+                setTrack(getRandomTrack());
+              }}
+            >
+              Randomize
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+```

--- a/packages/website/src/pages/docs/api/timeline.mdx
+++ b/packages/website/src/pages/docs/api/timeline.mdx
@@ -39,6 +39,7 @@ interface TimelineProps<State extends object = any> {
   playbackSpeed?: number;
   interval?: number;
   endBehavior?: TimelineEndBehavior;
+  avoidReload?: boolean;
   easing?: EasingFunction;
   interp?: InterpolationFunction;
   resolver?: TrackLayerResolver<State>;
@@ -57,7 +58,7 @@ interface TimelineProps<State extends object = any> {
 The array of regions that make up the animation.
 
 `track` is passed into `TrackUtils.gen()` immediately after `Timeline` mounts, calculating the `Animation`.
-After `Timeline` initializes, it will not re-calculate the animation if `track` changes.
+After `Timeline` initializes, it will not re-calculate the animation if `track` changes when `avoidReload = true`.
 
 ### defaultState
 
@@ -67,7 +68,7 @@ After `Timeline` initializes, it will not re-calculate the animation if `track` 
 The animation's default state. Must be an object.
 
 `defaultState` is passed into `TrackUtils.gen()` immediately after `Timeline` mounts, calculating the `Animation`.
-After `Timeline` initializes, it will not re-calculate the animation if `defaultState` changes.
+After `Timeline` initializes, it will not re-calculate the animation if `defaultState` changes when `avoidReload = true`.
 
 ### value
 
@@ -116,6 +117,51 @@ There are unavoidable (but minor) delays caused by querying the animation object
 - Default: `"stop"`
 
 Describes how the engine will calculate frame states for time values greater than the length of the animation.
+
+### avoidReload
+
+- Type: `boolean`
+- Default: `true`
+- _Since: v1.1.0_
+
+Whether or not `Timeline` will rebuild the animation when references to `track` or `defaultState` change.
+
+This property is `true` by default, meaning the animation will rebuild only when `endBehavior`, `easing`, `interp`, or `resolver` change.
+Changing `track` or `defaultState` will have no effect post-initialization.
+
+Setting `avoidReload` to `false` can be helpful if you want an animation to change dynamically after the `Timeline` has already initialized.
+
+**Disabling this prop can have negative performance effects** for your animation if `track` or `defaultState` are redefined on every render of your parent component.
+Be sure to define `track` and `defaultState` outside your render function or properly memoize them.
+
+```js
+// Instead of this:
+() => {
+  return (
+    <Timeline
+      avoidReload={false}
+      track={[{ duration: 1000 /* etc */ }]}
+      defaultState={{ x: 0 }}
+      {...props}
+    />
+  );
+};
+
+// Do this:
+() => {
+  const track = React.useMemo(() => [{ duration: 1000 /* etc */ }], []);
+  const defaultState = React.useMemo(() => ({ x: 0 }), []);
+
+  return (
+    <Timeline
+      avoidReload={false}
+      track={track}
+      defaultState={defaultState}
+      {...props}
+    />
+  );
+};
+```
 
 ### easing
 
@@ -199,3 +245,8 @@ See [`LoadEvent`](/docs/api/types#loadevent).
 - `easing`
 - `interp`
 - `resolver`
+
+If `avoidReload = false`, `Timeline` will also initialize whenever these props change:
+
+- `track`
+- `defaultState`

--- a/packages/website/src/pages/docs/api/timeline.mdx
+++ b/packages/website/src/pages/docs/api/timeline.mdx
@@ -134,7 +134,7 @@ Setting `avoidReload` to `false` can be helpful if you want an animation to chan
 **Disabling this prop can have negative performance effects** for your animation if `track` or `defaultState` are redefined on every render of your parent component.
 Be sure to define `track` and `defaultState` outside your render function or properly memoize them.
 
-```js
+```jsx
 // Instead of this:
 () => {
   return (

--- a/packages/website/src/pages/docs/examples.mdx
+++ b/packages/website/src/pages/docs/examples.mdx
@@ -27,3 +27,9 @@ import QuickStart from "../../content/examples/quick-start.mdx";
 import TrackLevelEasing from "../../content/examples/track-level-easing.mdx";
 
 <TrackLevelEasing />
+
+## Dynamic Reload
+
+import LiveReload from "../../content/examples/live-reload.mdx";
+
+<LiveReload />


### PR DESCRIPTION
…ing track after init

True by default, which will have the same behavior as before. If set to false, the animation will
reload when track or defaultState change.